### PR TITLE
Fix zkdel

### DIFF
--- a/lib/puppet/parser/functions/zkdel.rb
+++ b/lib/puppet/parser/functions/zkdel.rb
@@ -8,7 +8,7 @@ require 'zk'
 module Puppet::Parser::Functions
     newfunction(:zkdel) do |args|
         path = args[0]
-        mtime = args[1].to_s
+        mtime = args[1].to_i
         if args.length > 2
             parent_path = args[2]
             min_nodes = args[3].to_i

--- a/lib/puppet/parser/functions/zkdel.rb
+++ b/lib/puppet/parser/functions/zkdel.rb
@@ -12,6 +12,8 @@ module Puppet::Parser::Functions
         if args.length > 2
             parent_path = args[2]
             min_nodes = args[3].to_i
+        else
+            parent_path = nil
         end
 
         begin
@@ -27,7 +29,7 @@ module Puppet::Parser::Functions
 
             node = zk.stat(path)
 
-            if defined?(parent_path)
+            if ! parent_path.nil?
                 parent_node = zk.stat(path)
                 if not parent_node.numChildren - 1 < min_nodes
                     return false

--- a/lib/puppet/parser/functions/zkdel.rb
+++ b/lib/puppet/parser/functions/zkdel.rb
@@ -34,7 +34,7 @@ module Puppet::Parser::Functions
                 end
             end
 
-            if node.mtime.to_i < Time.now.to_i - mtime
+            if node.mtime.to_i < (Time.now.to_i * 1000) - mtime
                 begin
                     zk.delete(path, :ignore => :no_node)
                 rescue ZK::Exceptions::NotEmpty

--- a/lib/puppet/parser/functions/zkdel.rb
+++ b/lib/puppet/parser/functions/zkdel.rb
@@ -34,7 +34,7 @@ module Puppet::Parser::Functions
                 end
             end
 
-            if stat.mtime.to_i < Time.now.to_i - mtime
+            if node.mtime.to_i < Time.now.to_i - mtime
                 begin
                     zk.delete(path, :ignore => :no_node)
                 rescue ZK::Exceptions::NotEmpty


### PR DESCRIPTION
Fixed multiple bugs in zkdel function. Didn't work at all. Also made it work with Puppet 3.x (see: https://docs.puppetlabs.com/guides/custom_functions.html#gotchas)
- mtime was converted to a string when it needed to be an integer (to calculate time difference)
- parameter stat didn't exist but was referenced to. Needed to be parameter node
- Time.now in ruby is without microseconde. mtime of node stat is with microseconde. So multiplied Time.now with 1000 to make it work properly.
- Puppet 3.x uses 'nil' when parameters are not defined. Puppet 2.x uses :undefined. Modified the code so that it allways sets the parameter to nil when it is not passed to the function to make it work on both Puppet versions.
