### PR TITLE
BUG: no implicit conversion of Fixnum into String, fixed.

### DIFF
--- a/lib/facter/zk_conf.rb
+++ b/lib/facter/zk_conf.rb
@@ -5,6 +5,6 @@ Facter.add("zk_server") do
 end
 Facter.add("zk_port") do
     setcode do
-        2181
+        '2181'
     end
 end


### PR DESCRIPTION
The port number was configured as an integer when the ruby code expected it to be a string.
