### PR TITLE
zkget now returns an empty string.

### DIFF
--- a/lib/puppet/parser/functions/zkget.rb
+++ b/lib/puppet/parser/functions/zkget.rb
@@ -30,9 +30,19 @@ module Puppet::Parser::Functions
             # Stopping the puppet run is good enough for me.
 
             if type == 'data'
-                data = zk.get(path).first
+                begin
+                    data = zk.get(path).first
+                rescue ZK::Exceptions::NoNode
+                    #NoNode? return empty string
+                    data = String.new
+                end
             elsif type == 'children'
-                data= zk.children(path)
+                begin
+                    data= zk.children(path)
+                rescue ZK::Exceptions::NoNode
+                    #NoNode? return empty string
+                    data = String.new
+                end
             else
                 raise Puppet::ParseError, "Unknown type of get: #{type}"
             end


### PR DESCRIPTION
Used to see the error message 'Error while evaluating a Function Call, inputs: {:path=>'blabla'}'  which was hard to debug and locate where the problem was.
