### PR TITLE
Fix dependency packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Go to the modules folder and type:
 # git clone https://github.com/manos/puppet-zookeeper-config-data.git zk_puppet
 ```
 
-When including the puppet class, the gem 'zk' should be installed automatically, but it does require these additional packages on the OS:
+When including the puppet class, the gem 'zk' should be installed automatically, but it does require these additional packages on the OS (these packages are installed when you include this zk_puppet class):
 * ruby-devel
 * patch
 * gcc

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,4 +13,9 @@ class zk_puppet {
         provider => gem,
     }
 
+    $additional_packages = [ 'ruby-devel', 'patch', 'gcc' ]
+    package { $additional_packages:
+        ensure => present,
+        before => Package['zk']
+    }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,22 @@
+{
+"name": "conclusionMC/puppet-zookeeper-config-data",
+"version": "1.0.0",
+"author": "manos",
+"summary": "This module enables other classes to get of put data directly from and to zookeeper without using hiera",
+"license": "Apache-2.0",
+"source": "https://github.com/ConclusionMC/puppet-zookeeper-config-data",
+"project_page": "https://github.com/ConclusionMC/puppet-zookeeper-config-data",
+"issues_url": "https://github.com/ConclusionMC/puppet-zookeeper-config-data/issues",
+"operatingsystem_support": [
+  {
+    "operatingsystem": "RedHat",
+    "operatingsystemrelease": [
+      "5",
+      "6",
+      "7"
+    ]
+  }
+],
+"dependencies": [
+  ]
+}


### PR DESCRIPTION
In de README stonden dat deze packages nodig waren voor een juiste werking van de zk_puppet class. De packages zijn nu toegevoegd aan deze module zodat deze automatisch geinstalleerd worden.
